### PR TITLE
Fixes incompatibility with new versions of Savon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,2 @@
-
 source 'https://rubygems.org'
 gemspec
-
-gem "httpclient", "~> 2.7.1"
-gem 'certifi', '~> 2018.1', '>= 2018.01.18'
-gem 'inifile', '~> 3.0'
-gem 'savon', github: 'savonrb/savon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,56 @@
+PATH
+  remote: .
+  specs:
+    nps_sdk (1.3.1)
+      certifi (~> 2018.1, >= 2018.01.18)
+      httpclient (~> 2.7.1)
+      inifile (~> 3.0.0)
+      savon (~> 2.12.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    akami (1.3.1)
+      gyoku (>= 0.4.0)
+      nokogiri
+    builder (3.2.4)
+    certifi (2018.01.18)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
+    httpclient (2.7.2)
+    httpi (2.4.5)
+      rack
+      socksify
+    inifile (3.0.0)
+    mini_portile2 (2.5.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nori (2.6.0)
+    public_suffix (4.0.6)
+    racc (1.5.2)
+    rack (2.2.3)
+    savon (2.12.1)
+      akami (~> 1.2)
+      builder (>= 2.1.2)
+      gyoku (~> 1.2)
+      httpi (~> 2.3)
+      nokogiri (>= 1.8.1)
+      nori (~> 2.4)
+      wasabi (~> 3.4)
+    socksify (1.7.1)
+    wasabi (3.6.1)
+      addressable
+      httpi (~> 2.0)
+      nokogiri (>= 1.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nps_sdk!
+
+BUNDLED WITH
+   1.17.3

--- a/bin/console.rb
+++ b/bin/console.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "nps_sdk"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/lib/nps/environments.rb
+++ b/lib/nps/environments.rb
@@ -25,8 +25,8 @@ module Nps
         end
         environments = [
             PRODUCTION_WSDL,
-            STAGING_WSDL,
             SANDBOX_WSDL,
+            STAGING_WSDL,
             DEVELOPMENT_WSDL,
             CUSTOM_WSDL
         ]

--- a/lib/nps/soap_client.rb
+++ b/lib/nps/soap_client.rb
@@ -99,7 +99,7 @@ module Nps
         }
         @client_config.merge!(lvl_config)
       end
-      
+
       if @verify_ssl
         ssl_config = {
             ssl_verify_mode: :peer,
@@ -154,7 +154,7 @@ module Nps
       if services.is_service_in_services_with_additional_details(service)
         return params
       end
-      info = {"SdkInfo" => Nps::Utils::SDK[:language] + ' SDK Version: ' + Nps::Version::VERSION}
+      info = {"SdkInfo" => Nps::Utils::SDK[:language] + ' SDK Version: ' + Nps::VERSION}
       if params.key?("psp_MerchantAdditionalDetails")
         params["psp_MerchantAdditionalDetails"] = params["psp_MerchantAdditionalDetails"].merge(info)
       else
@@ -170,8 +170,8 @@ module Nps
       end
       unless params.has_key? 'psp_ClientSession'
         params = add_secure_hash(params)
-      end 
-      params = {"Requerimiento" => params}
+      end
+      params = { requerimiento: params }
 
         if @custom_env_urls
           internal_connection_timeout = @read_timeout
@@ -195,7 +195,7 @@ module Nps
               next
             rescue HTTPClient::ReceiveTimeoutError
               raise ApiException
-            rescue StandardError 
+            rescue StandardError
               raise 'An unexpected error occurred'
             end
           end
@@ -205,7 +205,7 @@ module Nps
             @client.call(service, message: params).body
           rescue HTTPClient::ReceiveTimeoutError
            raise ApiException
-          rescue StandardError 
+          rescue StandardError
            raise 'An unexpected error occurred'
          end
        end

--- a/lib/nps/version.rb
+++ b/lib/nps/version.rb
@@ -1,5 +1,3 @@
 module Nps
-  class Version
-    VERSION = '1.3.0'
-  end
+  VERSION = '1.3.1'
 end

--- a/nps_sdk.gemspec
+++ b/nps_sdk.gemspec
@@ -1,15 +1,21 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require "nps/version"
+
 Gem::Specification.new do |s|
   s.name        = 'nps_sdk'
-  s.version     = '1.3.0'
+  s.version     = Nps::VERSION
   s.date        = '2018-03-12'
   s.summary     = "SDK!"
   s.description = "Ruby SDK for NPS Services"
   s.authors     = ["merchantservices@ingenico.com"]
   s.email       = 'merchantservices@ingenico.com'
-  s.add_runtime_dependency 'savon', '~> 2.11'
+  s.add_runtime_dependency 'savon', '~> 2.12.1'
   s.add_runtime_dependency 'httpclient', '~> 2.7.1'
   s.add_runtime_dependency 'certifi', '~> 2018.1', '>= 2018.01.18'
-  s.add_runtime_dependency 'inifile', '~> 3.0'
+  s.add_runtime_dependency 'inifile', '~> 3.0.0'
   s.files       = ["lib/nps_sdk.rb",
                    "lib/nps/sdk.rb",
                    "lib/nps/nps_formatter.rb",


### PR DESCRIPTION
## Problem
The nps-sdk gem is allowing the Savon dependency to be upgraded from v2.11, but with the Savon v2.11.2 release, compatibility has been broken due to the body message key transformation

```ruby
message_locals = @locals[:message][message.snakecase.to_sym]
```
https://github.com/savonrb/savon/blob/v2.11.2/lib/savon/builder.rb#L163 

```
  <env:Body>
    <CreateClientSession>
      <Requerimiento xsi:type="tns:RequerimientoStruct_CreateClientSession"/>
    </CreateClientSession>
  </env:Body>
</env:Envelope>

2021-02-11 14:06:59 -0300 - DEBUG - NpsSDK - HTTPI /peer POST request to services2.nps.com.ar (httpclient)
2021-02-11 14:06:59 -0300 - INFO - NpsSDK - SOAP response (status 500)
2021-02-11 14:06:59 -0300 - DEBUG - NpsSDK - Date: Wed, 10 Feb 2021 17:55:57 GMT
```

## Solution
Set the key to the standard expected by Savon


```ruby
params = { requerimiento: params }
```

## Environment

- RUBYGEMS VERSION: 3.0.8
- RUBY VERSION: 2.6.6 (2020-03-31 patchlevel 146) [x86_64-darwin19]
